### PR TITLE
Load Library Error Handling

### DIFF
--- a/FastText.NetWrapper.sln
+++ b/FastText.NetWrapper.sln
@@ -9,26 +9,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtil", "TestUtil\TestUt
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|x64.ActiveCfg = Debug|x64
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|x64.Build.0 = Debug|x64
-		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|x64.ActiveCfg = Release|x64
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|x64.Build.0 = Release|x64
-		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|x64.ActiveCfg = Debug|x64
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|x64.Build.0 = Debug|x64
-		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|x64.ActiveCfg = Release|x64
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/FastText.NetWrapper.sln
+++ b/FastText.NetWrapper.sln
@@ -9,16 +9,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtil", "TestUtil\TestUt
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|x64.ActiveCfg = Debug|x64
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Debug|x64.Build.0 = Debug|x64
+		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|x64.ActiveCfg = Release|x64
 		{E9BCD9F6-D9D9-4F12-B440-6B65585106B0}.Release|x64.Build.0 = Release|x64
+		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|x64.ActiveCfg = Debug|x64
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Debug|x64.Build.0 = Debug|x64
+		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|x64.ActiveCfg = Release|x64
 		{4530C4C1-77DC-44DB-8199-3B0BAE6E4656}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/FastText.NetWrapper/FastText.NetWrapper.csproj
+++ b/FastText.NetWrapper/FastText.NetWrapper.csproj
@@ -34,27 +34,6 @@
     <DocumentationFile>bin\x64\Release\FastText.NetWrapper.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\x64\Release\FastText.NetWrapper.xml</DocumentationFile>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/FastText.NetWrapper/FastText.NetWrapper.csproj
+++ b/FastText.NetWrapper/FastText.NetWrapper.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FastText.NetWrapper</RootNamespace>
     <AssemblyName>FastText.NetWrapper</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -32,6 +33,27 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\x64\Release\FastText.NetWrapper.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\x64\Release\FastText.NetWrapper.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# FastText.NetWrapper
+
+## Table of contents
+
+* [Requirements](#requirements)
+
+## Requirements
+
+To run on a Windows host (.NET Framework), the host must have VS Runtime Version 140 installed. Visit the MS Downloads page (https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) and select the appropriate redistributable. 
+

--- a/TestUtil/App.config
+++ b/TestUtil/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
     </startup>
 </configuration>

--- a/TestUtil/TestUtil.csproj
+++ b/TestUtil/TestUtil.csproj
@@ -33,26 +33,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TestUtil/TestUtil.csproj
+++ b/TestUtil/TestUtil.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>TestUtil</RootNamespace>
     <AssemblyName>TestUtil</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -28,6 +29,26 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>


### PR DESCRIPTION
Changes: when there is an error loading the FastText.dll as a resource, detailed information is written to the log file and an exception is thrown.

When we were deploying this library to a host that didn't have Visual Studio installed, we were running into FastText.dll load errors. I added a README.md with a note for the redistributable requirement. 
